### PR TITLE
fix react-dom shim to avoid circular import

### DIFF
--- a/src/shims/react-dom.ts
+++ b/src/shims/react-dom.ts
@@ -1,7 +1,10 @@
 /* Shim for libraries that import { render } from 'react-dom' in React 18+ */
-import * as ReactDOMOriginal from "react-dom";
-export * from "react-dom";
-export { default } from "react-dom";
+// Re-export everything from the real react-dom package. We reference the
+// file in node_modules directly to bypass the alias defined in
+// vite.config.ts and avoid a circular self-import when this shim resolves as
+// "react-dom".
+export * from "../../node_modules/react-dom/index.js";
+export { default } from "../../node_modules/react-dom/index.js";
 
 import { createRoot } from "react-dom/client";
 


### PR DESCRIPTION
## Summary
- prevent circular self-import in `react-dom` shim by re-exporting from actual package

## Testing
- `pnpm lint` (fails: existing lint errors)
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a10ea7cb48832aabafc72ce1ddf912